### PR TITLE
Subscribeの自動破棄

### DIFF
--- a/BotManager.Reactive/DisposableEx.cs
+++ b/BotManager.Reactive/DisposableEx.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -35,5 +36,37 @@ namespace BotManager.Reactive
         {
             return new DisposalNotifier(baseDisposable);
         }
+
+        #region Then
+
+        /// <summary>
+        /// <see cref="IDisposable.Dispose"/>を呼び出したときに実行する処理を登録します。
+        /// </summary>
+        /// <param name="baseDisposable"></param>
+        /// <param name="dispose">実行する処理</param>
+        /// <returns></returns>
+        public static IDisposable Then(this IDisposable baseDisposable, Action dispose)
+        {
+            CompositeDisposable disposables = new();
+            disposables.Add(baseDisposable);
+            disposables.Add(Disposable.Create(dispose));
+            return disposables;
+        }
+
+        /// <summary>
+        /// <see cref="IDisposable.Dispose"/>を呼び出したときに実行する処理を登録します。
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="disposable"></param>
+        /// <param name="dispose">実行する処理</param>
+        /// <returns></returns>
+        public static IDisposable Then<T>(this T disposable, Action<T> dispose) where T : IDisposable
+        {
+            CompositeDisposable disposables = new();
+            disposables.Add(disposable);
+            disposables.Add(Disposable.Create(disposable, dispose));
+            return disposables;
+        }
+        #endregion
     }
 }

--- a/BotManager.Reactive/SubscriptionEx.cs
+++ b/BotManager.Reactive/SubscriptionEx.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BotManager.Reactive
+{
+    /// <summary>
+    /// サブスクリプション拡張メソッド
+    /// </summary>
+    public static class SubscriptionEx
+    {
+        #region SubscribeUntilDispose
+        /// <summary>
+        /// 値が通知されると指定した処理を実行するようにします。
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="observable"></param>
+        /// <param name="onNext">値が通知されると実行される処理。第2引数はこのメソッドの <see cref="IDisposable.Dispose"/>が呼ばれると通知されるオブジェクト。</param>
+        /// <returns></returns>
+        public static IDisposable InterlockedSubscribe<T>(this IObservable<T> observable, Action<T, IObservable<Unit>> onNext)
+        {
+            CompositeDisposable disposables = new();
+            var notifier = disposables.ToNotifiable();
+            disposables.Add(observable.Subscribe(t => onNext(t, notifier)));
+            return notifier;
+        }
+
+        /// <summary>
+        /// 値が通知されると指定した処理を実行するようにします。
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="observable"></param>
+        /// <param name="onNext">値が通知されると実行される処理。第2引数はこのメソッドの <see cref="IDisposable.Dispose"/>が呼ばれると通知されるオブジェクト。</param>
+        /// <param name="onError">エラーが通知された時に実行する処理</param>
+        /// <returns></returns>
+        public static IDisposable InterlockedSubscribe<T>(this IObservable<T> observable, Action<T, IObservable<Unit>> onNext, Action<Exception> onError)
+        {
+            CompositeDisposable disposables = new();
+            var notifier = disposables.ToNotifiable();
+            disposables.Add(observable.Subscribe(t => onNext(t, notifier), onError));
+            return notifier;
+        }
+
+        /// <summary>
+        /// 値が通知されると指定した処理を実行するようにします。
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="observable"></param>
+        /// <param name="onNext">値が通知されると実行される処理。第2引数はこのメソッドの <see cref="IDisposable.Dispose"/>が呼ばれると通知されるオブジェクト。</param>
+        /// <param name="onCompleted">値の発行が完了した時に実行する処理</param>
+        /// <returns></returns>
+        public static IDisposable InterlockedSubscribe<T>(this IObservable<T> observable, Action<T, IObservable<Unit>> onNext, Action onCompleted)
+        {
+            CompositeDisposable disposables = new();
+            var notifier = disposables.ToNotifiable();
+            disposables.Add(observable.Subscribe(t => onNext(t, notifier), onCompleted));
+            return notifier;
+        }
+
+        /// <summary>
+        /// 値が通知されると指定した処理を実行するようにします。
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="observable"></param>
+        /// <param name="onNext">値が通知されると実行される処理。第2引数はこのメソッドの <see cref="IDisposable.Dispose"/>が呼ばれると通知されるオブジェクト。</param>
+        /// <param name="onError">エラーが通知された時に実行する処理</param>
+        /// <param name="onCompleted">値の発行が完了した時に実行する処理</param>
+        /// <returns></returns>
+        public static IDisposable InterlockedSubscribe<T>(this IObservable<T> observable, Action<T, IObservable<Unit>> onNext, Action<Exception> onError, Action onCompleted)
+        {
+            CompositeDisposable disposables = new();
+            var notifier = disposables.ToNotifiable();
+            disposables.Add(observable.Subscribe(t => onNext(t, notifier), onError, onCompleted));
+            return notifier;
+        }
+        #endregion
+    }
+}

--- a/Notifiers.Test/ReactiveTest.cs
+++ b/Notifiers.Test/ReactiveTest.cs
@@ -1,0 +1,42 @@
+﻿using BotManager.Reactive;
+using Microsoft.Reactive.Testing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace Notifiers.Test
+{
+    public class ReactiveTest
+    {
+        private readonly ITestOutputHelper output;
+
+        public ReactiveTest(ITestOutputHelper helper)
+        {
+            this.output = helper;
+        }
+
+        [Fact(DisplayName = "Interlocked Disposal Subscription")]
+        public async Task InterlockDisposingTest()
+        {
+            var numobs = Observable
+                .Interval(TimeSpan.FromSeconds(1))
+                .GroupBy(n => n % 10)
+                ;
+
+            var subscription = numobs.InterlockedSubscribe((g, d) =>
+            {
+                // Disposeされたことを受け取れるかテスト
+                g
+                .TakeUntil(d)
+                .Finally(() => output.WriteLine("Disposing"))
+                .Subscribe(n => output.WriteLine("{0}-{1}", g.Key, n));
+            });
+            await Task.Delay(25000);
+            subscription.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
- `InterlockedSubscribe`拡張メソッドで大元で`Dispose()`が呼ばれた時に内部の式で通知を受け取れるようにした。
- `Dispose()`が呼ばれた時に特定の処理を実行させることが出来る`Then()`拡張メソッド追加。
- `IDisposable.DisposeOn<TSignal>(IObservable<TSignal>)`メソッドを呼び出すことで、引数に指定した通知者から通知された時に自動的に`Dispose()`を呼び出すように設定できる。